### PR TITLE
disconnectFromLocalNetwork: reject the promise there is an unhandled exception

### DIFF
--- a/packages/wifi/android/src/main/java/com/reactnativetethering/wifi/WifiTethering.kt
+++ b/packages/wifi/android/src/main/java/com/reactnativetethering/wifi/WifiTethering.kt
@@ -489,13 +489,17 @@ class WifiTethering(private val context: ReactApplicationContext) {
   }
 
   fun disconnectFromLocalNetwork(promise: Promise) {
-    if (isAndroidTenOrLater()) {
-      connectivityManager.bindProcessToNetwork(null)
-      connectivityManager.unregisterNetworkCallback(connectivityNetworkListener)
-      promise.resolve(null)
-    } else {
-      CustomPromise(promise).reject(UnsupportedApiException())
-    }
+		try {
+			if (isAndroidTenOrLater()) {
+				connectivityManager.bindProcessToNetwork(null)
+				connectivityManager.unregisterNetworkCallback(connectivityNetworkListener)
+				promise.resolve(null)
+			} else {
+				CustomPromise(promise).reject(UnsupportedApiException())
+			}
+		} catch (e: Exception) {
+			CustomPromise(promise).reject(CodedException(e))
+		}
   }
 
   fun disconnectFromNetwork(promise: Promise) {


### PR DESCRIPTION
It's pretty easy to get "NetworkCallback was not registered" error when disconnecting from a local network which is unhandled one. The PR handles it and rejects returned promise if it has been thrown.